### PR TITLE
typos getContructor

### DIFF
--- a/src/stores/contracts.js
+++ b/src/stores/contracts.js
@@ -275,7 +275,7 @@ export const useContractStore = defineStore({
         },
         async decodeConstructor(address, data) {
             try {
-                let constructor = await this.getContructor(address);
+                let constructor = await this.getConstructor(address);
                 let res = ethers.utils.defaultAbiCoder.decode(
                     constructor.inputs.map(x => x.type),
                     data


### PR DESCRIPTION
I think that there is a mistake getContructor. getContructor is not in the repository code. So it should be called function getConstructor which is located just below.